### PR TITLE
HAI-871 Allow users to expose ports from dind container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update \
 
 # Docker daemon
 RUN curl "https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VERSION}.tgz" -o /docker.tgz \
-    && tar -xz -f /docker.tgz --strip-components=1 -C /usr/local/bin docker/dockerd \
+    && tar -xz -f /docker.tgz --strip-components=1 -C /usr/local/bin docker/dockerd docker/docker-proxy \
     && rm -f /docker.tgz
 
 # NVIDIA container toolkit


### PR DESCRIPTION
## Related Tasks

- HAI-871

## What

- Add docker-proxy so users can expose ports.
 
## Why

- Users want to run services via docker and expose ports.

## Notes

- This will still only allow access within the same namespace when a security policy applies. This has been tested.
