### PR TITLE
HAI-1010 Add pigz to improve compression performance

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update \
        dumb-init rootlesskit slirp4netns \
        iptables iproute2 ca-certificates \
        containerd runc curl gnupg python3-pip \
+       pigz \
     && rm -rf \
        /usr/bin/rootlessctl \
        /usr/bin/containerd-shim-runc-v1 \


### PR DESCRIPTION
## Related Tasks

- HAI-1010

## What

- Add pigz

## Why

- Docker implements a feature to use pigz if available on the system which improves compression operations: https://github.com/moby/moby/pull/35697
