### PR TITLE
Transition from Dockerhub to Github container registry

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,14 +1,11 @@
 name: Build and publish
 
 on:
-  # pull_request:
-  #   branches:
-  #     - main
-  # release:
-  #   types: [published]
-  push:
+  pull_request:
     branches:
-      - 7-ghcr-migration
+      - main
+  release:
+    types: [published]
 
 jobs:
   build:
@@ -25,15 +22,14 @@ jobs:
 
       - name: Log in to ghcr
         uses: docker/login-action@v2
-        #if: github.event_name == 'release'
+        if: github.event_name == 'release'
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish the image
-        #if: github.event_name == 'release'
+        if: github.event_name == 'release'
         run: make publish
         env:
-          TAG: "test"
-          #TAG: ${{ github.ref_name }}
+          TAG: ${{ github.ref_name }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,14 +25,15 @@ jobs:
 
       - name: Log in to ghcr
         uses: docker/login-action@v2
-        if: github.event_name == 'release'
+        #if: github.event_name == 'release'
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish the image
-        if: github.event_name == 'release'
+        #if: github.event_name == 'release'
         run: make publish
         env:
-          TAG: test
+          TAG: "test"
+          #TAG: ${{ github.ref_name }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,28 +1,35 @@
 name: Build and publish
 
 on:
-  pull_request:
+  # pull_request:
+  #   branches:
+  #     - main
+  # release:
+  #   types: [published]
+  push:
     branches:
-      - main
-  release:
-    types: [published]
+      - 7-ghcr-migration
 
 jobs:
   build:
     name: Build and publish
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v3
 
       - name: Build the image
         run: make build
 
-      - name: Log in to Docker Hub
+      - name: Log in to ghcr
         uses: docker/login-action@v2
         if: github.event_name == 'release'
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish the image
         if: github.event_name == 'release'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,4 +35,4 @@ jobs:
         if: github.event_name == 'release'
         run: make publish
         env:
-          TAG: ${{ github.ref_name }}
+          TAG: test

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 
 .DEFAULT_GOAL := help
-IMAGE_NAME := ghcr.io/harrison-ai/rootless-nvidia-dind:latest
+IMAGE_NAME := ghcr.io/harrison-ai/cobalt-rootless-nvidia-dind
 
 ## build:                       build the docker image
 build:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 
 .DEFAULT_GOAL := help
-IMAGE_NAME := harrisonai/cobalt-rootless-nvidia-dind
+IMAGE_NAME := ghcr.io/harrison-ai/rootless-nvidia-dind:latest
 
 ## build:                       build the docker image
 build:


### PR DESCRIPTION
## Related Tasks

- #7

## What

- Move image publishing to Github container registry.
- Manually trigger a release.
- Manually set package permission to public.
- Manually remove the Dockerhub secret.

There will be a subsequent request to update the Coder template after it's been tested manually.

## Why

- We're transitioning from Dockerhub

## Notes

- Test action: https://github.com/harrison-ai/cobalt-docker-rootless-nvidia-dind/actions/runs/4560091100
